### PR TITLE
Add internal-cluster-test plugin to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ repositories {
 }
 
 apply plugin: 'opensearch.opensearchplugin'
+apply plugin: 'opensearch.internal-cluster-test'
 
 opensearchplugin {
   name 'custom-codecs'


### PR DESCRIPTION
This enables the integration tests to run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
