### PR TITLE
Add version info to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
   ext {
     opensearch_group = "org.opensearch"
     opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+    buildVersionQualifier = System.getProperty("build.version_qualifier", "")
   }
 
   repositories {
@@ -39,11 +41,22 @@ repositories {
   maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 
+allprojects {
+  group 'org.opensearch'
+  version = opensearch_version.tokenize('-')[0] + '.0'
+  if (buildVersionQualifier) {
+    version += "-${buildVersionQualifier}"
+  }
+  if (isSnapshot) {
+    version += "-SNAPSHOT"
+  }
+}
+
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.internal-cluster-test'
 
 opensearchplugin {
-  name 'custom-codecs'
+  name 'opensearch-custom-codecs'
   description 'A plugin that implements custom compression codecs.'
   classname 'org.opensearch.index.codec.customcodecs.CustomCodecPlugin'
   licenseFile rootProject.file('LICENSE')


### PR DESCRIPTION
I copied this approach from other plugin repos, for example [common-utils][1].

[1]: https://github.com/opensearch-project/common-utils/blob/7736e080f9b0a2f6f2d9ad3b4272090b281ea8fa/build.gradle#L43-L52

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
