### PR TITLE
Add workflow to publish snapshots to maven

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -1,0 +1,35 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+
+jobs:
+  build-and-publish-snapshots:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository


### PR DESCRIPTION
### Description
Adds workflow to publish snapshots to maven. Tested locally:

```
[root@dcda507af0e2 snapshots]# tree org
org
`-- opensearch
    `-- plugin
        `-- custom-codecs
            |-- 3.0.0.0-SNAPSHOT
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.pom
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.pom.md5
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.pom.sha1
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.pom.sha256
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.pom.sha512
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.zip
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.zip.md5
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.zip.sha1
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.zip.sha256
            |   |-- custom-codecs-3.0.0.0-20230908.172334-1.zip.sha512
            |   |-- maven-metadata.xml
            |   |-- maven-metadata.xml.md5
            |   |-- maven-metadata.xml.sha1
            |   |-- maven-metadata.xml.sha256
            |   `-- maven-metadata.xml.sha512
            |-- maven-metadata.xml
            |-- maven-metadata.xml.md5
            |-- maven-metadata.xml.sha1
            |-- maven-metadata.xml.sha256
            `-- maven-metadata.xml.sha512
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
