### PR TITLE
Publish only ZIP artifacts since the plugin has no xxx-client counterpart

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,3 +19,6 @@ jobs:
       - name: Run Gradle (check)
         run: |
           ./gradlew check
+      - name: Run Gradle (assemble)
+        run: |
+          ./gradlew assemble

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ allprojects {
         }
         publications {
             // add license information to generated poms
-            all {
+            pluginZip(MavenPublication) { publication ->
                 pom {
                     name = "opensearch-custom-codecs"
                     description = "OpenSearch plugin that implements custom compression codecs"
@@ -190,4 +190,13 @@ integTest {
 testClusters.integTest {
     testDistribution = "ARCHIVE"
     plugin(project.tasks.bundlePlugin.archiveFile)
+}
+
+tasks.withType(PublishToMavenRepository) {
+    def predicate = provider {
+        publication.name == "pluginZip"
+    }
+    onlyIf("Publishing only ZIP distributions") {
+        predicate.get()
+    }
 }


### PR DESCRIPTION
### Description
Publish only ZIP artifacts since the plugin has no xxx-client counterpart

```
$ ./scripts/build.sh -s true -v 3.0.0
```

```
$ tree build/local-staging-repo/org/opensearch/
build/local-staging-repo/org/opensearch/
└── plugin
    └── opensearch-custom-codecs
        ├── 3.0.0.0-SNAPSHOT
        │   ├── maven-metadata.xml
        │   ├── maven-metadata.xml.md5
        │   ├── maven-metadata.xml.sha1
        │   ├── maven-metadata.xml.sha256
        │   ├── maven-metadata.xml.sha512
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.pom
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.pom.md5
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.pom.sha1
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.pom.sha256
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.pom.sha512
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.zip
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.zip.md5
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.zip.sha1
        │   ├── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.zip.sha256
        │   └── opensearch-custom-codecs-3.0.0.0-20231004.151629-1.zip.sha512
        ├── maven-metadata.xml
        ├── maven-metadata.xml.md5
        ├── maven-metadata.xml.sha1
        ├── maven-metadata.xml.sha256
        └── maven-metadata.xml.sha512
```

### Issues Resolved
Closes https://github.com/opensearch-project/custom-codecs/issues/68

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
