### PR TITLE
Removed explicit -Druntime.java version specifier for Gradle check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,12 +27,12 @@ jobs:
         run: |
           # https://github.com/opensearch-project/opensearch-build/issues/4191
           chown -R opensearch:opensearch `pwd`
-          su opensearch -c "source /etc/profile.d/java_home.sh && ./gradlew check -Druntime.java=${{ matrix.java }}"
+          su opensearch -c "source /etc/profile.d/java_home.sh && ./gradlew check -Dorg.gradle.java.home=/opt/java/openjdk-${{ matrix.java }}"
       - name: Run Gradle (assemble)
         run: |
           # https://github.com/opensearch-project/opensearch-build/issues/4191
           chown -R opensearch:opensearch `pwd`
-          su opensearch -c "source /etc/profile.d/java_home.sh && ./gradlew assemble -Druntime.java=${{ matrix.java }}"
+          su opensearch -c "source /etc/profile.d/java_home.sh && ./gradlew assemble -Dorg.gradle.java.home=/opt/java/openjdk-${{ matrix.java }}"
 
   precommit-windows-macos:
     if: github.repository == 'opensearch-project/custom-codecs'


### PR DESCRIPTION
### Description
Removed explicit -Druntime.java version specifier for Gradle check

### Issues Resolved
Forwardport from https://github.com/opensearch-project/custom-codecs/pull/77

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
