### PR TITLE
Remove redundant array resizing in Zstd compression modes.

### DIFF
--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
@@ -188,7 +188,6 @@ public class ZstdCompressionMode extends CompressionMode {
 
                     // Read blocks that intersect with the interval we need
                     while (offsetInBlock < offset + length) {
-                        bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + blockLength);
                         int l = Math.min(blockLength, originalLength - offsetInBlock);
                         doDecompress(in, dctx, bytes, l);
                         offsetInBlock += blockLength;

--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
@@ -148,7 +148,6 @@ public class ZstdNoDictCompressionMode extends CompressionMode {
 
             // Read blocks that intersect with the interval we need
             while (offsetInBlock < offset + length) {
-                bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + blockLength);
                 final int compressedLength = in.readVInt();
                 if (compressedLength == 0) {
                     return;
@@ -159,10 +158,7 @@ public class ZstdNoDictCompressionMode extends CompressionMode {
                 int l = Math.min(blockLength, originalLength - offsetInBlock);
                 bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + l);
 
-                byte[] output = new byte[l];
-
-                final int uncompressed = (int) Zstd.decompressByteArray(output, 0, l, compressed, 0, compressedLength);
-                System.arraycopy(output, 0, bytes.bytes, bytes.length, uncompressed);
+                final int uncompressed = (int) Zstd.decompressByteArray(bytes.bytes, bytes.length, l, compressed, 0, compressedLength);
 
                 bytes.length += uncompressed;
                 offsetInBlock += blockLength;


### PR DESCRIPTION
### Description
Removes redundant array resizes in Zstd compression modes.

### Issues Resolved
Improves performance by eliminating redundant array resizing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
