### PR TITLE
Add hardware-accelerated DEFLATE and LZ4 compression codec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ opensearchplugin {
 
 dependencies {
   api "com.github.luben:zstd-jni:1.5.5-5"
+  api "com.intel.qat:qat-java:1.1.1"
 }
 
 allprojects {

--- a/licenses/qat-java-1.1.0.jar.sha1
+++ b/licenses/qat-java-1.1.0.jar.sha1
@@ -1,0 +1,1 @@
+fbcaabdbf9d2a72d4b8222e7cfb2043a68b7860e

--- a/licenses/qat-java-LICENSE.txt
+++ b/licenses/qat-java-LICENSE.txt
@@ -1,0 +1,36 @@
+-----------------------------------------------------------------------------
+** Beginning of "BSD License" text. **
+
+Qat-Java: Qat-Java is a compression library that uses Intel® QAT to accelerate
+compression and decompression.
+
+Copyright(c) 2007-2023 Intel Corporation. All rights reserved.
+All rights reserved.
+
+BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Intel Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/qat-java-NOTICE.txt
+++ b/licenses/qat-java-NOTICE.txt
@@ -1,0 +1,1 @@
+Qat-Java is a compression library that uses Intel® QAT to accelerate compression and decompression.

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
@@ -8,28 +8,47 @@
 
 package org.opensearch.index.codec.customcodecs;
 
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.codec.CodecServiceFactory;
 import org.opensearch.index.engine.EngineConfig;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.Plugin;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+
+import com.intel.qat.QatZipper;
 
 /**
  * A plugin that implements custom codecs. Supports these codecs:
+ *
  * <ul>
- * <li>ZSTD
- * <li>ZSTDNODICT
+ *   <li>ZSTD_CODEC
+ *   <li>ZSTD_NO_DICT_CODEC
+ *   <li>QAT_DEFLATE
+ *   <li>QAT_LZ4
  * </ul>
  *
  * @opensearch.internal
  */
 public final class CustomCodecPlugin extends Plugin implements EnginePlugin {
 
-    /**
-     * Creates a new instance
-     */
+    /** A setting to specifiy the QAT acceleration mode. */
+    public static final Setting<QatZipper.Mode> INDEX_CODEC_QAT_MODE_SETTING = new Setting<>("index.codec.qatmode", "hardware", s -> {
+        switch (s) {
+            case "auto":
+                return QatZipper.Mode.AUTO;
+            case "hardware":
+                return QatZipper.Mode.HARDWARE;
+            default:
+                throw new IllegalArgumentException("Unknown value for [index.codec.qatmode] must be one of [auto, hardware] but was: " + s);
+        }
+    }, Property.IndexScope, Property.Dynamic);
+
+    /** Creates a new instance */
     public CustomCodecPlugin() {}
 
     /**
@@ -39,9 +58,17 @@ public final class CustomCodecPlugin extends Plugin implements EnginePlugin {
     @Override
     public Optional<CodecServiceFactory> getCustomCodecServiceFactory(final IndexSettings indexSettings) {
         String codecName = indexSettings.getValue(EngineConfig.INDEX_CODEC_SETTING);
-        if (codecName.equals(CustomCodecService.ZSTD_NO_DICT_CODEC) || codecName.equals(CustomCodecService.ZSTD_CODEC)) {
+        if (codecName.equals(CustomCodecService.ZSTD_NO_DICT_CODEC)
+            || codecName.equals(CustomCodecService.ZSTD_CODEC)
+            || codecName.equals(CustomCodecService.QAT_DEFLATE_CODEC)
+            || codecName.equals(CustomCodecService.QAT_LZ4_CODEC)) {
             return Optional.of(new CustomCodecServiceFactory());
         }
         return Optional.empty();
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(INDEX_CODEC_QAT_MODE_SETTING);
     }
 }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecServiceFactory.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecServiceFactory.java
@@ -12,9 +12,7 @@ import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.codec.CodecServiceConfig;
 import org.opensearch.index.codec.CodecServiceFactory;
 
-/**
- * A factory for creating new {@link CodecService} instance
- */
+/** A factory for creating new {@link CodecService} instance */
 public class CustomCodecServiceFactory implements CodecServiceFactory {
 
     /** Creates a new instance. */

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene99CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene99CustomStoredFieldsFormat.java
@@ -17,10 +17,12 @@ import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
-import org.opensearch.index.codec.customcodecs.backward_codecs.Lucene95CustomCodec;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Supplier;
+
+import com.intel.qat.QatZipper;
 
 /** Stored field format used by pluggable codec */
 public class Lucene99CustomStoredFieldsFormat extends StoredFieldsFormat {
@@ -32,8 +34,18 @@ public class Lucene99CustomStoredFieldsFormat extends StoredFieldsFormat {
     protected static final int ZSTD_MAX_DOCS_PER_BLOCK = 4096;
     protected static final int ZSTD_BLOCK_SHIFT = 10;
 
+    private static final int QAT_DEFLATE_BLOCK_LENGTH = 10 * 48 * 1024;
+    private static final int QAT_DEFLATE_MAX_DOCS_PER_BLOCK = 4096;
+    private static final int QAT_DEFLATE_BLOCK_SHIFT = 10;
+
+    private static final int QAT_LZ4_BLOCK_LENGTH = 10 * 8 * 1024;
+    private static final int QAT_LZ4_MAX_DOCS_PER_BLOCK = 4096;
+    private static final int QATLZ4_BLOCK_SHIFT = 10;
+
     private final CompressionMode zstdCompressionMode;
     private final CompressionMode zstdNoDictCompressionMode;
+    private final CompressionMode qatDeflateCompressionMode;
+    private final CompressionMode qatLz4CompressionMode;
 
     private final Lucene99CustomCodec.Mode mode;
     private final int compressionLevel;
@@ -46,35 +58,59 @@ public class Lucene99CustomStoredFieldsFormat extends StoredFieldsFormat {
     /**
      * Creates a new instance.
      *
-     * @param mode The mode represents ZSTD or ZSTDNODICT
+     * @param mode The mode represents ZSTD, ZSTDNODICT, QAT_DEFLATE, or QAT_LZ4
      */
     public Lucene99CustomStoredFieldsFormat(Lucene99CustomCodec.Mode mode) {
         this(mode, Lucene99CustomCodec.DEFAULT_COMPRESSION_LEVEL);
     }
 
     /**
+     * Creates a new instance.
+     *
+     * @param mode The mode represents ZSTD, ZSTDNODICT, QAT_DEFLATE, or QAT_LZ4
+     * @param supplier a supplier for QAT acceleration mode.
+     */
+    public Lucene99CustomStoredFieldsFormat(Lucene99CustomCodec.Mode mode, Supplier<QatZipper.Mode> supplier) {
+        this(mode, Lucene99CustomCodec.DEFAULT_COMPRESSION_LEVEL, supplier);
+    }
+
+    /**
      * Creates a new instance with the specified mode and compression level.
      *
-     * @param mode The mode represents ZSTD or ZSTDNODICT
+     * @param mode The mode represents ZSTD, ZSTDNODICT, QAT_DEFLATE, or QAT_LZ4
      * @param compressionLevel The compression level for the mode.
      */
     public Lucene99CustomStoredFieldsFormat(Lucene99CustomCodec.Mode mode, int compressionLevel) {
+        this(mode, compressionLevel, () -> { return Lucene99CustomCodec.DEFAULT_QAT_MODE; });
+    }
+
+    /**
+     * Creates a new instance with the specified mode and compression level.
+     *
+     * @param mode The mode represents ZSTD, ZSTDNODICT, QAT_DEFLATE, or QAT_LZ4
+     * @param compressionLevel The compression level for the mode.
+     * @param supplier a supplier for QAT acceleration mode.
+     */
+    public Lucene99CustomStoredFieldsFormat(Lucene99CustomCodec.Mode mode, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
         this.mode = Objects.requireNonNull(mode);
         this.compressionLevel = compressionLevel;
         zstdCompressionMode = new ZstdCompressionMode(compressionLevel);
         zstdNoDictCompressionMode = new ZstdNoDictCompressionMode(compressionLevel);
+        qatDeflateCompressionMode = new QatDeflateCompressionMode(compressionLevel, supplier);
+        qatLz4CompressionMode = new QatLz4CompressionMode(compressionLevel, supplier);
     }
 
     /**
-      * Returns a {@link StoredFieldsReader} to load stored fields.
-      * @param directory The index directory.
-      * @param si The SegmentInfo that stores segment information.
-      * @param fn The fieldInfos.
-      * @param context The IOContext that holds additional details on the merge/search context.
-    */
+     * Returns a {@link StoredFieldsReader} to load stored fields.
+     *
+     * @param directory The index directory.
+     * @param si The SegmentInfo that stores segment information.
+     * @param fn The fieldInfos.
+     * @param context The IOContext that holds additional details on the merge/search context.
+     */
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
-        if (si.getAttribute(MODE_KEY) !=null){
+        if (si.getAttribute(MODE_KEY) != null) {
             String value = si.getAttribute(MODE_KEY);
             Lucene99CustomCodec.Mode mode = Lucene99CustomCodec.Mode.valueOf(value);
             return impl(mode).fieldsReader(directory, si, fn, context);
@@ -84,11 +120,12 @@ public class Lucene99CustomStoredFieldsFormat extends StoredFieldsFormat {
     }
 
     /**
-      * Returns a {@link StoredFieldsReader} to write stored fields.
-      * @param directory The index directory.
-      * @param si The SegmentInfo that stores segment information.
-      * @param context The IOContext that holds additional details on the merge/search context.
-    */
+     * Returns a {@link StoredFieldsReader} to write stored fields.
+     *
+     * @param directory The index directory.
+     * @param si The SegmentInfo that stores segment information.
+     * @param context The IOContext that holds additional details on the merge/search context.
+     */
     @Override
     public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context) throws IOException {
         String previous = si.putAttribute(MODE_KEY, mode.name());
@@ -106,35 +143,68 @@ public class Lucene99CustomStoredFieldsFormat extends StoredFieldsFormat {
                 return getCustomCompressingStoredFieldsFormat("CustomStoredFieldsZstd", this.zstdCompressionMode);
             case ZSTD_NO_DICT:
                 return getCustomCompressingStoredFieldsFormat("CustomStoredFieldsZstdNoDict", this.zstdNoDictCompressionMode);
+            case QAT_DEFLATE:
+                return getCustomCompressingStoredFieldsFormat(
+                    "CustomStoredFieldsQatDeflate",
+                    this.qatDeflateCompressionMode,
+                    QAT_DEFLATE_BLOCK_LENGTH,
+                    QAT_DEFLATE_MAX_DOCS_PER_BLOCK,
+                    QAT_DEFLATE_BLOCK_SHIFT
+                );
+            case QAT_LZ4:
+                return getCustomCompressingStoredFieldsFormat(
+                    "CustomStoredFieldsQatLz4",
+                    this.qatLz4CompressionMode,
+                    QAT_LZ4_BLOCK_LENGTH,
+                    QAT_DEFLATE_MAX_DOCS_PER_BLOCK,
+                    QAT_DEFLATE_BLOCK_SHIFT
+                );
             default:
                 throw new AssertionError();
         }
     }
 
-
     private StoredFieldsFormat getCustomCompressingStoredFieldsFormat(String formatName, CompressionMode compressionMode) {
-        return new Lucene90CompressingStoredFieldsFormat(
-                formatName,
-                compressionMode,
-                ZSTD_BLOCK_LENGTH,
-                ZSTD_MAX_DOCS_PER_BLOCK,
-                ZSTD_BLOCK_SHIFT
+        return getCustomCompressingStoredFieldsFormat(
+            formatName,
+            compressionMode,
+            ZSTD_BLOCK_LENGTH,
+            ZSTD_MAX_DOCS_PER_BLOCK,
+            ZSTD_BLOCK_SHIFT
         );
+    }
+
+    private StoredFieldsFormat getCustomCompressingStoredFieldsFormat(
+        String formatName,
+        CompressionMode compressionMode,
+        int blockSize,
+        int maxDocs,
+        int blockShift
+    ) {
+        return new Lucene90CompressingStoredFieldsFormat(formatName, compressionMode, blockSize, maxDocs, blockShift);
     }
 
     public Lucene99CustomCodec.Mode getMode() {
         return mode;
     }
 
-    /**
-     * Returns the compression level.
-     */
+    /** Returns the compression level. */
     public int getCompressionLevel() {
         return compressionLevel;
     }
 
     public CompressionMode getCompressionMode() {
-        return mode == Lucene99CustomCodec.Mode.ZSTD_NO_DICT ? zstdNoDictCompressionMode : zstdCompressionMode;
+        switch (mode) {
+            case ZSTD:
+                return zstdCompressionMode;
+            case ZSTD_NO_DICT:
+                return zstdNoDictCompressionMode;
+            case QAT_DEFLATE:
+                return qatDeflateCompressionMode;
+            case QAT_LZ4:
+                return qatLz4CompressionMode;
+            default:
+                throw new AssertionError();
+        }
     }
-
 }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate99Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate99Codec.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.customcodecs;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.index.codec.CodecAliases;
+import org.opensearch.index.codec.CodecSettings;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.mapper.MapperService;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.intel.qat.QatZipper;
+
+/**
+ * QatDeflate99Codec provides a DEFLATE compressor using the <a
+ * href="https://github.com/intel/qat-java">qat-java</a> library.
+ */
+public class QatDeflate99Codec extends Lucene99CustomCodec implements CodecSettings, CodecAliases {
+
+    /** Creates a new QatDeflate99Codec instance with the default compression level. */
+    public QatDeflate99Codec() {
+        this(DEFAULT_COMPRESSION_LEVEL);
+    }
+
+    /**
+     * Creates a new QatDeflate99Codec instance.
+     *
+     * @param compressionLevel The compression level.
+     */
+    public QatDeflate99Codec(int compressionLevel) {
+        super(Mode.QAT_DEFLATE, compressionLevel);
+    }
+
+    /**
+     * Creates a new QatDeflate99Codec instance with the default compression level.
+     *
+     * @param compressionLevel The compression level.
+     * @param supplier supplier for QAT acceleration mode.
+     */
+    public QatDeflate99Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        super(Mode.QAT_DEFLATE, compressionLevel, supplier);
+    }
+
+    /**
+     * Creates a new QatDeflate99Codec instance.
+     *
+     * @param mapperService The mapper service.
+     * @param logger The logger.
+     * @param compressionLevel The compression level.
+     */
+    public QatDeflate99Codec(MapperService mapperService, Logger logger, int compressionLevel) {
+        super(Mode.QAT_DEFLATE, compressionLevel, mapperService, logger);
+    }
+
+    /**
+     * Creates a new QatDeflate99Codec instance.
+     *
+     * @param mapperService The mapper service.
+     * @param logger The logger.
+     * @param compressionLevel The compression level.
+     * @param supplier supplier for QAT acceleration mode.
+     */
+    public QatDeflate99Codec(MapperService mapperService, Logger logger, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        super(Mode.QAT_DEFLATE, compressionLevel, mapperService, logger, supplier);
+    }
+
+    /** The name for this codec. */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean supports(Setting<?> setting) {
+        return setting.equals(EngineConfig.INDEX_CODEC_COMPRESSION_LEVEL_SETTING);
+    }
+
+    @Override
+    public Set<String> aliases() {
+        return Mode.QAT_DEFLATE.getAliases();
+    }
+}

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflateCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflateCompressionMode.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.customcodecs;
+
+import org.apache.lucene.codecs.compressing.CompressionMode;
+import org.apache.lucene.codecs.compressing.Compressor;
+import org.apache.lucene.codecs.compressing.Decompressor;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import com.intel.qat.QatZipper;
+
+/** QAT_DEFLATE ompression Mode */
+public class QatDeflateCompressionMode extends CompressionMode {
+
+    private static final int NUM_SUB_BLOCKS = 10;
+    private static final int DEFAULT_COMPRESSION_LEVEL = 6;
+
+    private final int compressionLevel;
+    private final Supplier<QatZipper.Mode> supplier;
+
+    /** default constructor */
+    protected QatDeflateCompressionMode() {
+        this.compressionLevel = DEFAULT_COMPRESSION_LEVEL;
+        this.supplier = () -> { return Lucene99CustomCodec.DEFAULT_QAT_MODE; };
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param compressionLevel The compression level to use.
+     * @param supplier a supplier for QAT acceleration mode.
+     */
+    protected QatDeflateCompressionMode(int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        this.compressionLevel = compressionLevel;
+        this.supplier = supplier;
+    }
+
+    @Override
+    public Compressor newCompressor() {
+        return new QatCompressor(compressionLevel, supplier.get());
+    }
+
+    @Override
+    public Decompressor newDecompressor() {
+        return new QatDecompressor(supplier.get());
+    }
+
+    /** QAT_DEFLATE compressor */
+    private static final class QatCompressor extends Compressor {
+
+        private byte[] compressedBuffer;
+
+        private QatZipper qatZipper;
+
+        /** compressor with a given compresion level */
+        public QatCompressor(int compressionLevel, QatZipper.Mode mode) {
+            compressedBuffer = BytesRef.EMPTY_BYTES;
+            qatZipper = QatZipperFactory.createInstance(
+                QatZipper.Algorithm.DEFLATE,
+                compressionLevel,
+                mode,
+                QatZipper.PollingMode.PERIODICAL
+            );
+        }
+
+        private void compress(byte[] bytes, int offset, int length, DataOutput out) throws IOException {
+            assert offset >= 0 : "Offset value must be greater than 0.";
+
+            int blockLength = (length + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
+            out.writeVInt(blockLength);
+
+            final int end = offset + length;
+            assert end >= 0 : "Buffer read size must be greater than 0.";
+
+            for (int start = offset; start < end; start += blockLength) {
+                int l = Math.min(blockLength, end - start);
+
+                if (l == 0) {
+                    out.writeVInt(0);
+                    return;
+                }
+
+                final int maxCompressedLength = qatZipper.maxCompressedLength(l);
+                compressedBuffer = ArrayUtil.grow(compressedBuffer, maxCompressedLength);
+
+                int compressedSize = qatZipper.compress(bytes, start, l, compressedBuffer, 0, compressedBuffer.length);
+                out.writeVInt(compressedSize);
+                out.writeBytes(compressedBuffer, compressedSize);
+            }
+        }
+
+        @Override
+        public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
+            final int length = (int) buffersInput.size();
+            byte[] bytes = new byte[length];
+            buffersInput.readBytes(bytes, 0, length);
+            compress(bytes, 0, length, out);
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    /** QAT_DEFLATE decompressor */
+    private static final class QatDecompressor extends Decompressor {
+
+        private byte[] compressed;
+        private QatZipper qatZipper;
+        final QatZipper.Mode qatMode;
+
+        /** default decompressor */
+        public QatDecompressor(QatZipper.Mode mode) {
+            compressed = BytesRef.EMPTY_BYTES;
+            qatZipper = QatZipperFactory.createInstance(QatZipper.Algorithm.DEFLATE, mode, QatZipper.PollingMode.PERIODICAL);
+            this.qatMode = mode;
+        }
+
+        /*resuable decompress function*/
+        @Override
+        public void decompress(DataInput in, int originalLength, int offset, int length, BytesRef bytes) throws IOException {
+            assert offset + length <= originalLength : "Buffer read size must be within limit.";
+
+            if (length == 0) {
+                bytes.length = 0;
+                return;
+            }
+
+            final int blockLength = in.readVInt();
+            bytes.offset = bytes.length = 0;
+            int offsetInBlock = 0;
+            int offsetInBytesRef = offset;
+
+            // Skip unneeded blocks
+            while (offsetInBlock + blockLength < offset) {
+                final int compressedLength = in.readVInt();
+                in.skipBytes(compressedLength);
+                offsetInBlock += blockLength;
+                offsetInBytesRef -= blockLength;
+            }
+
+            // Read blocks that intersect with the interval we need
+            while (offsetInBlock < offset + length) {
+                final int compressedLength = in.readVInt();
+                if (compressedLength == 0) {
+                    return;
+                }
+                compressed = ArrayUtil.grow(compressed, compressedLength);
+                in.readBytes(compressed, 0, compressedLength);
+
+                int l = Math.min(blockLength, originalLength - offsetInBlock);
+                bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + l);
+
+                final int uncompressed = qatZipper.decompress(compressed, 0, compressedLength, bytes.bytes, bytes.length, l);
+
+                bytes.length += uncompressed;
+                offsetInBlock += blockLength;
+            }
+
+            bytes.offset = offsetInBytesRef;
+            bytes.length = length;
+
+            assert bytes.isValid() : "Decompression output is corrupted.";
+        }
+
+        @Override
+        public Decompressor clone() {
+            return new QatDecompressor(qatMode);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatLz499Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatLz499Codec.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.customcodecs;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.index.codec.CodecAliases;
+import org.opensearch.index.codec.CodecSettings;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.mapper.MapperService;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.intel.qat.QatZipper;
+
+/**
+ * QatLz499Codec provides an LZ4 compressor using the <a
+ * href="https://github.com/intel/qat-java">qat-java</a> library.
+ */
+public class QatLz499Codec extends Lucene99CustomCodec implements CodecSettings, CodecAliases {
+
+    /** Creates a new QatLz499Codec instance with the default compression level. */
+    public QatLz499Codec() {
+        this(DEFAULT_COMPRESSION_LEVEL);
+    }
+
+    /**
+     * Creates a new QatLz499Codec instance.
+     *
+     * @param compressionLevel The compression level.
+     */
+    public QatLz499Codec(int compressionLevel) {
+        super(Mode.QAT_LZ4, compressionLevel);
+    }
+
+    /**
+     * Creates a new QatLz499Codec instance with the default compression level.
+     *
+     * @param compressionLevel The compression level.
+     * @param supplier supplier for QAT acceleration mode.
+     */
+    public QatLz499Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        super(Mode.QAT_LZ4, compressionLevel, supplier);
+    }
+
+    /**
+     * Creates a new QatLz499Codec instance.
+     *
+     * @param mapperService The mapper service.
+     * @param logger The logger.
+     * @param compressionLevel The compression level.
+     */
+    public QatLz499Codec(MapperService mapperService, Logger logger, int compressionLevel) {
+        super(Mode.QAT_LZ4, compressionLevel, mapperService, logger);
+    }
+
+    /**
+     * Creates a new QatLz499Codec instance.
+     *
+     * @param mapperService The mapper service.
+     * @param logger The logger.
+     * @param compressionLevel The compression level.
+     * @param supplier supplier for QAT acceleration mode.
+     */
+    public QatLz499Codec(MapperService mapperService, Logger logger, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        super(Mode.QAT_LZ4, compressionLevel, mapperService, logger, supplier);
+    }
+
+    /** The name for this codec. */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean supports(Setting<?> setting) {
+        return setting.equals(EngineConfig.INDEX_CODEC_COMPRESSION_LEVEL_SETTING);
+    }
+
+    @Override
+    public Set<String> aliases() {
+        return Mode.QAT_LZ4.getAliases();
+    }
+}

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4CompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4CompressionMode.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.customcodecs;
+
+import org.apache.lucene.codecs.compressing.CompressionMode;
+import org.apache.lucene.codecs.compressing.Compressor;
+import org.apache.lucene.codecs.compressing.Decompressor;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import com.intel.qat.QatZipper;
+
+/** QAT_LZ4 Compression Mode */
+public class QatLz4CompressionMode extends CompressionMode {
+
+    private static final int NUM_SUB_BLOCKS = 10;
+    private static final int DEFAULT_COMPRESSION_LEVEL = 6;
+
+    private final int compressionLevel;
+    private final Supplier<QatZipper.Mode> supplier;
+
+    /** default constructor */
+    protected QatLz4CompressionMode() {
+        this.compressionLevel = DEFAULT_COMPRESSION_LEVEL;
+        this.supplier = () -> { return Lucene99CustomCodec.DEFAULT_QAT_MODE; };
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param compressionLevel The compression level to use.
+     * @param supplier a supplier for QAT acceleration mode.
+     */
+    protected QatLz4CompressionMode(int compressionLevel, Supplier<QatZipper.Mode> supplier) {
+        this.compressionLevel = compressionLevel;
+        this.supplier = supplier;
+    }
+
+    @Override
+    public Compressor newCompressor() {
+        return new QatCompressor(compressionLevel, supplier.get());
+    }
+
+    @Override
+    public Decompressor newDecompressor() {
+        return new QatDecompressor(supplier.get());
+    }
+
+    /** QAT_LZ4 compressor */
+    private static final class QatCompressor extends Compressor {
+
+        private byte[] compressedBuffer;
+
+        private QatZipper qatZipper;
+
+        /** compressor with a given compresion level */
+        public QatCompressor(int compressionLevel, QatZipper.Mode mode) {
+            compressedBuffer = BytesRef.EMPTY_BYTES;
+            qatZipper = QatZipperFactory.createInstance(QatZipper.Algorithm.LZ4, compressionLevel, mode, QatZipper.PollingMode.PERIODICAL);
+        }
+
+        private void compress(byte[] bytes, int offset, int length, DataOutput out) throws IOException {
+            assert offset >= 0 : "Offset value must be greater than 0.";
+
+            int blockLength = (length + NUM_SUB_BLOCKS - 1) / NUM_SUB_BLOCKS;
+            out.writeVInt(blockLength);
+
+            final int end = offset + length;
+            assert end >= 0 : "Buffer read size must be greater than 0.";
+
+            for (int start = offset; start < end; start += blockLength) {
+                int l = Math.min(blockLength, end - start);
+
+                if (l == 0) {
+                    out.writeVInt(0);
+                    return;
+                }
+
+                final int maxCompressedLength = qatZipper.maxCompressedLength(l);
+                compressedBuffer = ArrayUtil.grow(compressedBuffer, maxCompressedLength);
+
+                int compressedSize = qatZipper.compress(bytes, start, l, compressedBuffer, 0, compressedBuffer.length);
+                out.writeVInt(compressedSize);
+                out.writeBytes(compressedBuffer, compressedSize);
+            }
+        }
+
+        @Override
+        public void compress(ByteBuffersDataInput buffersInput, DataOutput out) throws IOException {
+            final int length = (int) buffersInput.size();
+            byte[] bytes = new byte[length];
+            buffersInput.readBytes(bytes, 0, length);
+            compress(bytes, 0, length, out);
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    /** QAT_LZ4 decompressor */
+    private static final class QatDecompressor extends Decompressor {
+
+        private byte[] compressed;
+        private QatZipper qatZipper;
+        private final QatZipper.Mode qatMode;
+
+        /** default decompressor */
+        public QatDecompressor(QatZipper.Mode mode) {
+            compressed = BytesRef.EMPTY_BYTES;
+            qatZipper = QatZipperFactory.createInstance(QatZipper.Algorithm.LZ4, mode, QatZipper.PollingMode.PERIODICAL);
+            qatMode = mode;
+        }
+
+        /*resuable decompress function*/
+        @Override
+        public void decompress(DataInput in, int originalLength, int offset, int length, BytesRef bytes) throws IOException {
+            assert offset + length <= originalLength : "Buffer read size must be within limit.";
+
+            if (length == 0) {
+                bytes.length = 0;
+                return;
+            }
+
+            final int blockLength = in.readVInt();
+            bytes.offset = bytes.length = 0;
+            int offsetInBlock = 0;
+            int offsetInBytesRef = offset;
+
+            // Skip unneeded blocks
+            while (offsetInBlock + blockLength < offset) {
+                final int compressedLength = in.readVInt();
+                in.skipBytes(compressedLength);
+                offsetInBlock += blockLength;
+                offsetInBytesRef -= blockLength;
+            }
+
+            // Read blocks that intersect with the interval we need
+            while (offsetInBlock < offset + length) {
+                final int compressedLength = in.readVInt();
+                if (compressedLength == 0) {
+                    return;
+                }
+                compressed = ArrayUtil.grow(compressed, compressedLength);
+                in.readBytes(compressed, 0, compressedLength);
+
+                int l = Math.min(blockLength, originalLength - offsetInBlock);
+                bytes.bytes = ArrayUtil.grow(bytes.bytes, bytes.length + l);
+
+                final int uncompressed = qatZipper.decompress(compressed, 0, compressedLength, bytes.bytes, bytes.length, l);
+
+                bytes.length += uncompressed;
+                offsetInBlock += blockLength;
+            }
+
+            bytes.offset = offsetInBytesRef;
+            bytes.length = length;
+
+            assert bytes.isValid() : "Decompression output is corrupted.";
+        }
+
+        @Override
+        public Decompressor clone() {
+            return new QatDecompressor(qatMode);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.codec.customcodecs;
+
+import com.intel.qat.QatZipper;
+
+import static com.intel.qat.QatZipper.Algorithm;
+import static com.intel.qat.QatZipper.DEFAULT_COMPRESS_LEVEL;
+import static com.intel.qat.QatZipper.DEFAULT_MODE;
+import static com.intel.qat.QatZipper.DEFAULT_POLLING_MODE;
+import static com.intel.qat.QatZipper.DEFAULT_RETRY_COUNT;
+import static com.intel.qat.QatZipper.Mode;
+import static com.intel.qat.QatZipper.PollingMode;
+
+/** A factory class to create instances of QatZipper */
+public class QatZipperFactory
+
+{
+
+    /**
+     * Creates a new QatZipper with the specified parameters.
+     *
+     * @param algorithm the compression algorithm
+     * @param level the compression level.
+     * @param mode the mode of QAT execution
+     * @param retryCount the number of attempts to acquire hardware resources
+     * @param pmode polling mode.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level, Mode mode, int retryCount, PollingMode pmode) {
+        return new QatZipper(algorithm, level, mode, retryCount, pmode);
+    }
+
+    /**
+     * Creates a new QatZipper that uses the DEFLATE algorithm and the default compression level,
+     * mode, retry count, and polling mode.
+     */
+    public static QatZipper createInstance() {
+        return createInstance(Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified compression algorithm. Uses the default compression
+     * level, mode, retry count, and polling mode.
+     *
+     * @param algorithm the compression algorithm
+     */
+    public static QatZipper createInstance(Algorithm algorithm) {
+        return createInstance(algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified execution mode. Uses the DEFLATE algorithm with the
+     * default compression level, retry count, and polling mode.
+     *
+     * @param mode the mode of QAT execution
+     */
+    public static QatZipper createInstance(Mode mode) {
+        return createInstance(Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified polling polling mode. Uses the DEFLATE algorithm
+     * with the default compression level, mode, and retry count.
+     *
+     * @param pmode the polling mode.
+     */
+    public static QatZipper createInstance(PollingMode pmode) {
+        return createInstance(Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm and compression level. Uses the default
+     * mode, retry count, and polling mode.
+     *
+     * @param algorithm the compression algorithm (deflate or LZ4).
+     * @param level the compression level.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level) {
+        return createInstance(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm and mode of execution. Uses the default
+     * compression level, retry count, and polling mode.
+     *
+     * @param algorithm the compression algorithm
+     * @param mode the mode of QAT execution
+     */
+    public static QatZipper createInstance(Algorithm algorithm, Mode mode) {
+        return createInstance(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm and polling mode of execution. Uses the
+     * default compression level, mode, and retry count.
+     *
+     * @param algorithm the compression algorithm
+     * @param pmode the polling mode.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, PollingMode pmode) {
+        return createInstance(algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm and mode of execution. Uses compression
+     * level and retry count.
+     *
+     * @param algorithm the compression algorithm
+     * @param mode the mode of QAT execution
+     * @param pmode the polling mode.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, Mode mode, PollingMode pmode) {
+        return createInstance(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, pmode);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm, compression level, and mode . Uses the
+     * default retry count and polling mode.
+     *
+     * @param algorithm the compression algorithm (deflate or LZ4).
+     * @param level the compression level.
+     * @param mode the mode of operation (HARDWARE - only hardware, AUTO - hardware with a software
+     *     failover.)
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level, Mode mode) {
+        return createInstance(algorithm, level, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified algorithm, compression level, and polling mode .
+     * Uses the default mode and retry count.
+     *
+     * @param algorithm the compression algorithm (deflate or LZ4).
+     * @param level the compression level.
+     * @param pmode the polling mode.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level, PollingMode pmode) {
+        return createInstance(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified parameters and polling mode.
+     *
+     * @param algorithm the compression algorithm
+     * @param level the compression level.
+     * @param mode the mode of QAT execution
+     * @param retryCount the number of attempts to acquire hardware resources
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level, Mode mode, int retryCount) {
+        return createInstance(algorithm, level, mode, retryCount, DEFAULT_POLLING_MODE);
+    }
+
+    /**
+     * Creates a new QatZipper with the specified parameters and retry count.
+     *
+     * @param algorithm the compression algorithm
+     * @param level the compression level.
+     * @param mode the mode of QAT execution
+     * @param pmode the polling mode.
+     */
+    public static QatZipper createInstance(Algorithm algorithm, int level, Mode mode, PollingMode pmode) {
+        return createInstance(algorithm, level, mode, DEFAULT_RETRY_COUNT, pmode);
+    }
+
+    /**
+     * Checks if QAT hardware is available.
+     *
+     * @return true if QAT hardware is available, false otherwise.
+     */
+    public static boolean isQatAvailable() {
+        try {
+            QatZipper qzip = QatZipperFactory.createInstance();
+            qzip.end();
+            return true;
+        } catch (UnsatisfiedLinkError | ExceptionInInitializerError | NoClassDefFoundError e) {
+            return false;
+        }
+    }
+}

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -9,3 +9,8 @@
 grant codeBase "${codebase.zstd-jni}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
 };
+
+grant codeBase "${codebase.qat-java}" {
+  permission java.lang.RuntimePermission "loadLibrary.*";
+  permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
+};

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -3,3 +3,5 @@ org.opensearch.index.codec.customcodecs.backward_codecs.ZstdNoDict95Codec
 org.opensearch.index.codec.customcodecs.backward_codecs.Zstd95DeprecatedCodec
 org.opensearch.index.codec.customcodecs.Zstd99Codec
 org.opensearch.index.codec.customcodecs.ZstdNoDict99Codec
+org.opensearch.index.codec.customcodecs.QatDeflate99Codec
+org.opensearch.index.codec.customcodecs.QatLz499Codec


### PR DESCRIPTION
### Description
Adds hardware-accelerated DEFLATE and LZ4 compression codecs for stored fields. The hardware in focus here is Intel (R) QAT, which is an integrated, built-in accelerator on the latest 4th and 5th Gen Intel Xeon processors. The implementation relies on the [Qat-Java ](https://github.com/intel/qat-java)library. 

The PR adds two additional valid values for `index.codec`:  `qat_deflate` and `qat_lz4`. It also introduces a new setting, `index.codec.qatmode`, that specifies the mode of execution for QAT.

Two values are supported for `index.codec.qatmode`: `hardware` and `auto`. A `hardware` execution mode uses only the QAT hardware, while an `auto` execution mode may switch to software if hardware resources are not available.

### Closes
https://github.com/opensearch-project/OpenSearch/pull/12351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
