### PR TITLE
[Backport] [2.x] Switch to macos-13 runner for assemble github actions due to macos-latest is now arm64 (#138)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/custom-codecs/pull/138 to `2.x`