### PR TITLE
Remove org.opensearch.secure_sm.ThreadPermission from plugin manifest, this permission should not be granted

### DIFF
--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -12,5 +12,4 @@ grant codeBase "${codebase.zstd-jni}" {
 
 grant codeBase "${codebase.qat-java}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
-  permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
 };


### PR DESCRIPTION
### Description
Remove org.opensearch.secure_sm.ThreadPermission from plugin manifest, this permission should not be granted

### Issues Resolved
Followup on https://github.com/opensearch-project/custom-codecs/pull/122

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
