### PR TITLE
Validating QAT Hardware Support before QAT Codecs are available

### DIFF
--- a/src/integrationTest/java/org/opensearch/index/codec/rest/CreateIndexWithCodecIT.java
+++ b/src/integrationTest/java/org/opensearch/index/codec/rest/CreateIndexWithCodecIT.java
@@ -20,11 +20,13 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
+import org.opensearch.index.codec.customcodecs.Lucene99QatCodec;
 import org.opensearch.index.codec.customcodecs.QatZipperFactory;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
@@ -65,6 +67,49 @@ public class CreateIndexWithCodecIT extends OpenSearchRestTestCase {
         } finally {
             deleteIndex(index);
         }
+    }
+
+    public void testCreateIndexWithQatCodecWithQatHardwareUnavailable() throws IOException {
+
+        assumeThat("Qat library is not available", QatZipperFactory.isQatAvailable(), is(false));
+        final String index = "custom-codecs-test-index";
+
+        // creating index
+        final ResponseException e = expectThrows(
+            ResponseException.class,
+            () -> createIndex(
+                index,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.codec", randomFrom(QAT_DEFLATE_CODEC, QAT_LZ4_CODEC))
+                    .put("index.codec.compression_level", randomIntBetween(1, 6))
+                    .build()
+            )
+        );
+        assertTrue(e.getResponse().toString().contains("400 Bad Request"));
+    }
+
+    public void testCreateIndexWithQatSPICodecWithQatHardwareUnavailable() throws IOException {
+
+        assumeThat("Qat library is not available", QatZipperFactory.isQatAvailable(), is(false));
+        final String index = "custom-codecs-test-index";
+
+        // creating index
+        final ResponseException e = expectThrows(
+            ResponseException.class,
+            () -> createIndex(
+                index,
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.codec", randomFrom(Lucene99QatCodec.Mode.QAT_LZ4.getCodec(), Lucene99QatCodec.Mode.QAT_DEFLATE.getCodec()))
+                    .put("index.codec.compression_level", randomIntBetween(1, 6))
+                    .build()
+            )
+        );
+        assertTrue(e.getResponse().toString().contains("400 Bad Request"));
+
     }
 
     public void testCreateIndexWithQatCodec() throws IOException {

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
@@ -48,6 +48,13 @@ public final class CustomCodecPlugin extends Plugin implements EnginePlugin {
             || codecName.equals(CustomCodecService.QAT_LZ4_CODEC)
             || codecName.equals(CustomCodecService.QAT_DEFLATE_CODEC)) {
             return Optional.of(new CustomCodecServiceFactory());
+        } else {
+            if (!QatZipperFactory.isQatAvailable()
+                && (codecName.equals(Lucene99QatCodec.Mode.QAT_LZ4.getCodec())
+                    || codecName.equals(Lucene99QatCodec.Mode.QAT_DEFLATE.getCodec()))) {
+                throw new IllegalArgumentException("QAT codecs are not supported. Please create indices with a different codec.");
+            }
+
         }
         return Optional.empty();
     }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecService.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecService.java
@@ -51,21 +51,25 @@ public class CustomCodecService extends CodecService {
         if (mapperService == null) {
             codecs.put(ZSTD_CODEC, new Zstd99Codec(compressionLevel));
             codecs.put(ZSTD_NO_DICT_CODEC, new ZstdNoDict99Codec(compressionLevel));
-            codecs.put(QAT_LZ4_CODEC, new QatLz499Codec(compressionLevel, () -> {
-                return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
-            }));
-            codecs.put(QAT_DEFLATE_CODEC, new QatDeflate99Codec(compressionLevel, () -> {
-                return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
-            }));
+            if (QatZipperFactory.isQatAvailable()) {
+                codecs.put(QAT_LZ4_CODEC, new QatLz499Codec(compressionLevel, () -> {
+                    return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
+                }));
+                codecs.put(QAT_DEFLATE_CODEC, new QatDeflate99Codec(compressionLevel, () -> {
+                    return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
+                }));
+            }
         } else {
             codecs.put(ZSTD_CODEC, new Zstd99Codec(mapperService, logger, compressionLevel));
             codecs.put(ZSTD_NO_DICT_CODEC, new ZstdNoDict99Codec(mapperService, logger, compressionLevel));
-            codecs.put(QAT_LZ4_CODEC, new QatLz499Codec(mapperService, logger, compressionLevel, () -> {
-                return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
-            }));
-            codecs.put(QAT_DEFLATE_CODEC, new QatDeflate99Codec(mapperService, logger, compressionLevel, () -> {
-                return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
-            }));
+            if (QatZipperFactory.isQatAvailable()) {
+                codecs.put(QAT_LZ4_CODEC, new QatLz499Codec(mapperService, logger, compressionLevel, () -> {
+                    return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
+                }));
+                codecs.put(QAT_DEFLATE_CODEC, new QatDeflate99Codec(mapperService, logger, compressionLevel, () -> {
+                    return indexSettings.getValue(Lucene99QatCodec.INDEX_CODEC_QAT_MODE_SETTING);
+                }));
+            }
         }
         this.codecs = codecs.immutableMap();
     }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate99Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate99Codec.java
@@ -86,6 +86,9 @@ public class QatDeflate99Codec extends Lucene99QatCodec implements CodecSettings
 
     @Override
     public Set<String> aliases() {
+        if (!QatZipperFactory.isQatAvailable()) {
+            return Set.of();
+        }
         return Mode.QAT_DEFLATE.getAliases();
     }
 }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatLz499Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatLz499Codec.java
@@ -86,6 +86,9 @@ public class QatLz499Codec extends Lucene99QatCodec implements CodecSettings, Co
 
     @Override
     public Set<String> aliases() {
+        if (!QatZipperFactory.isQatAvailable()) {
+            return Set.of();
+        }
         return Mode.QAT_LZ4.getAliases();
     }
 }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
@@ -172,12 +172,25 @@ public class QatZipperFactory {
      * @return true if QAT hardware is available, false otherwise.
      */
     public static boolean isQatAvailable() {
-        try {
-            QatZipper qzip = QatZipperFactory.createInstance();
-            qzip.end();
-            return true;
-        } catch (UnsatisfiedLinkError | ExceptionInInitializerError | NoClassDefFoundError e) {
-            return false;
+        return QatAvailableHolder.IS_QAT_AVAILABLE;
+    }
+
+    /**
+     * Nested class to defer static initialization until {@link #isQatAvailable()} is invoked
+     */
+    private static class QatAvailableHolder {
+        static final boolean IS_QAT_AVAILABLE;
+
+        static {
+            boolean isQatAvailable;
+            try {
+                final QatZipper qzip = QatZipperFactory.createInstance();
+                qzip.end();
+                isQatAvailable = true;
+            } catch (UnsatisfiedLinkError | ExceptionInInitializerError | NoClassDefFoundError e) {
+                isQatAvailable = false;
+            }
+            IS_QAT_AVAILABLE = isQatAvailable;
         }
     }
 }


### PR DESCRIPTION
### Description
Validates that we only load the QAT codecs if QAT library is loaded

### Issues Resolved
#168

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
