### PR TITLE
Bump 2.x to 2.18.0 since 2.17.0 branch was cut already

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 buildscript {
   ext {
     opensearch_group = "org.opensearch"
-    opensearch_version = System.getProperty("opensearch.version", "2.17.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "2.18.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
   }

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,7 +44,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.17.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.18.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
     repositories {


### PR DESCRIPTION
### Description
Bump 2.x to 2.18.0 since 2.17.0 branch was cut already

### Related Issues
N/A (part of the release)

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
