### PR TITLE
Wrap a call to QatZipper with AccessController.doPrivileged.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,13 +18,11 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+      - uses: actions/checkout@v4
       - name: Run Gradle (check)
         run: |
           # https://github.com/opensearch-project/opensearch-build/issues/4191
@@ -44,7 +42,7 @@ jobs:
         os: [windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
@@ -31,7 +31,9 @@ public class QatZipperFactory {
      * @param pmode polling mode.
      */
     public static QatZipper createInstance(Algorithm algorithm, int level, Mode mode, int retryCount, PollingMode pmode) {
-        return new QatZipper(algorithm, level, mode, retryCount, pmode);
+        return java.security.AccessController.doPrivileged(
+            (java.security.PrivilegedAction<QatZipper>) () -> new QatZipper(algorithm, level, mode, retryCount, pmode)
+        );
     }
 
     /**

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -12,4 +12,5 @@ grant codeBase "${codebase.zstd-jni}" {
 
 grant codeBase "${codebase.qat-java}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
+  permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
 };

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -12,5 +12,4 @@ grant codeBase "${codebase.zstd-jni}" {
 
 grant codeBase "${codebase.qat-java}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
-  permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
 };


### PR DESCRIPTION
A customer reached out to inform us that they were unable to use `qat_deflate` and `qat_lz4`. Upon investigation, I discovered that `isQATAvailable()` was returning `false` due to a `java.security` permission fail in [here](https://github.com/opensearch-project/custom-codecs/blob/main/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java#L187). This behavior is unexpected, as my initial PR did not require it (as far as I can remember). 

This PR addresses the issue by adding the necessary permission to the `qat-java` codebase.

@sarthakaggarwal97

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
