### PR TITLE
Bump ZTD lib version to 1.5.6-1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ opensearchplugin {
 }
 
 dependencies {
-  api "com.github.luben:zstd-jni:1.5.5-5"
+  api "com.github.luben:zstd-jni:1.5.6-1"
   api "com.intel.qat:qat-java:1.1.1"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
     opensearch_group = "org.opensearch"
     opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+    buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
   }
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@
 buildscript {
   ext {
     opensearch_group = "org.opensearch"
-    opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
   }


### PR DESCRIPTION
### Description
Bumped up the ZSTD library to version 1.5.6-1. This version adds support for custom sequence producers, which makes it possible to add QAT-accelerated ZSTD, in addition to the existing `qat_deflate` and `qat_lz4`.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
