### PR TITLE
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,9 +91,18 @@ opensearchplugin {
   noticeFile rootProject.file('NOTICE')
 }
 
+configurations {
+  agent
+}
+
+
 dependencies {
   api "com.github.luben:zstd-jni:1.5.6-1"
   api "com.intel.qat:qat-java:1.1.1"
+
+  agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+  agent "org.opensearch:opensearch-agent:${opensearch_version}"
+  agent "net.bytebuddy:byte-buddy:1.17.5"
 }
 
 allprojects {
@@ -196,17 +205,24 @@ tasks.named("testingConventions").configure {
     }
 }
 
+internalClusterTest {
+  dependsOn "prepareAgent"
+  jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+}
+
 integTest {
     description = "Run tests against a cluster"
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
 
-    dependsOn "bundlePlugin"
+    dependsOn "bundlePlugin", "prepareAgent"
     systemProperty 'tests.security.manager', 'true'
 
     systemProperty "https", System.getProperty("https")
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
+
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }
 
 testClusters.integTest {
@@ -231,4 +247,14 @@ task updateVersion {
         // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
+}
+
+task prepareAgent(type: Copy) {
+  from(configurations.agent)
+  into "$buildDir/agent"
+}
+
+tasks.test {
+  dependsOn prepareAgent
+  jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,14 +95,13 @@ configurations {
   agent
 }
 
-
 dependencies {
   api "com.github.luben:zstd-jni:1.5.6-1"
   api "com.intel.qat:qat-java:1.1.1"
 
   agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
   agent "org.opensearch:opensearch-agent:${opensearch_version}"
-  agent "net.bytebuddy:byte-buddy:1.17.5"
+  agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
 
 allprojects {
@@ -205,24 +204,17 @@ tasks.named("testingConventions").configure {
     }
 }
 
-internalClusterTest {
-  dependsOn "prepareAgent"
-  jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
-}
-
 integTest {
     description = "Run tests against a cluster"
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
 
-    dependsOn "bundlePlugin", "prepareAgent"
+    dependsOn "bundlePlugin"
     systemProperty 'tests.security.manager', 'true'
 
     systemProperty "https", System.getProperty("https")
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
-
-    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }
 
 testClusters.integTest {
@@ -254,7 +246,7 @@ task prepareAgent(type: Copy) {
   into "$buildDir/agent"
 }
 
-tasks.test {
+tasks.withType(Test) {
   dependsOn prepareAgent
   jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -6,6 +6,10 @@
  * compatible open source license.
  */
 
+grant {
+  permission java.net.NetPermission "accessUnixDomainSocket";
+}
+
 grant codeBase "${codebase.zstd-jni}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
 };

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -6,10 +6,6 @@
  * compatible open source license.
  */
 
-grant {
-  permission java.net.NetPermission "accessUnixDomainSocket";
-}
-
 grant codeBase "${codebase.zstd-jni}" {
   permission java.lang.RuntimePermission "loadLibrary.*";
 };


### PR DESCRIPTION
### Description
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
