### PR TITLE
Use java-agent Gradle plugin to support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.internal-cluster-test'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.rest-test'
+apply plugin: 'opensearch.java-agent'
 apply from: 'gradle/formatting.gradle'
 
 repositories {
@@ -91,17 +92,9 @@ opensearchplugin {
   noticeFile rootProject.file('NOTICE')
 }
 
-configurations {
-  agent
-}
-
 dependencies {
   api "com.github.luben:zstd-jni:1.5.6-1"
   api "com.intel.qat:qat-java:1.1.1"
-
-  agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-  agent "org.opensearch:opensearch-agent:${opensearch_version}"
-  agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
 
 allprojects {
@@ -239,14 +232,4 @@ task updateVersion {
         // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-}
-
-task prepareAgent(type: Copy) {
-  from(configurations.agent)
-  into "$buildDir/agent"
-}
-
-tasks.withType(Test) {
-  dependsOn prepareAgent
-  jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }


### PR DESCRIPTION
### Description
Since the PR https://github.com/opensearch-project/OpenSearch/pull/17900 is now merged we can just apply the gradle plugin, reverting https://github.com/opensearch-project/custom-codecs/pull/235.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
