### PR TITLE
Adding support for composite index

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@
 buildscript {
   ext {
     opensearch_group = "org.opensearch"
-    opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
   }

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecService.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecService.java
@@ -53,8 +53,8 @@ public class CustomCodecService extends CodecService {
         super(mapperService, indexSettings, logger);
         int compressionLevel = indexSettings.getValue(INDEX_CODEC_COMPRESSION_LEVEL_SETTING);
         final MapBuilder<String, Codec> codecs = MapBuilder.<String, Codec>newMapBuilder();
-        // setup "default" codec from OpenSearch core to delegate
-        Supplier<Codec> defaultCodecSupplier = () -> super.codec("default");
+        // Delegate to OpenSearch "default" codec
+        Supplier<Codec> defaultCodecSupplier = () -> super.defaultCodec();
         if (mapperService == null) {
             codecs.put(ZSTD_CODEC, new Zstd101Codec(compressionLevel));
             codecs.put(ZSTD_NO_DICT_CODEC, new ZstdNoDict101Codec(compressionLevel));

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
@@ -8,16 +8,13 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene101.Lucene101Codec;
-import org.opensearch.index.codec.PerFieldMappingPostingFormatCodec;
-import org.opensearch.index.codec.composite.composite101.Composite101Codec;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.opensearch.index.codec.customcodecs.backward_codecs.lucene99.Lucene99CustomCodec.DEFAULT_COMPRESSION_LEVEL;
 
@@ -96,20 +93,11 @@ public abstract class Lucene101CustomCodec extends FilterCodec {
      *
      * @param mode The compression codec (ZSTD or ZSTDNODICT).
      * @param compressionLevel The compression level.
-     * @param mapperService The mapper service.
-     * @param logger The logger.
+     * @param defaultCodecSupplier Default codec supplier
      */
-    public Lucene101CustomCodec(Mode mode, int compressionLevel, MapperService mapperService, Logger logger) {
-        super(mode.getCodec(), getDelegateCodec(mapperService, logger));
+    public Lucene101CustomCodec(Mode mode, int compressionLevel, Supplier<Codec> defaultCodecSupplier) {
+        super(mode.getCodec(), defaultCodecSupplier.get());
         this.storedFieldsFormat = new Lucene101CustomStoredFieldsFormat(mode, compressionLevel);
-    }
-
-    private static Codec getDelegateCodec(MapperService mapperService, Logger logger) {
-        if (mapperService.isCompositeIndexPresent()) {
-            return new Composite101Codec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger);
-        } else {
-            return new PerFieldMappingPostingFormatCodec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger);
-        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
@@ -9,10 +9,12 @@
 package org.opensearch.index.codec.customcodecs;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene101.Lucene101Codec;
 import org.opensearch.index.codec.PerFieldMappingPostingFormatCodec;
+import org.opensearch.index.codec.composite.composite101.Composite101Codec;
 import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
@@ -98,8 +100,16 @@ public abstract class Lucene101CustomCodec extends FilterCodec {
      * @param logger The logger.
      */
     public Lucene101CustomCodec(Mode mode, int compressionLevel, MapperService mapperService, Logger logger) {
-        super(mode.getCodec(), new PerFieldMappingPostingFormatCodec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger));
+        super(mode.getCodec(), getDelegateCodec(mapperService, logger));
         this.storedFieldsFormat = new Lucene101CustomStoredFieldsFormat(mode, compressionLevel);
+    }
+
+    private static Codec getDelegateCodec(MapperService mapperService, Logger logger) {
+        if (mapperService.isCompositeIndexPresent()) {
+            return new Composite101Codec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger);
+        } else {
+            return new PerFieldMappingPostingFormatCodec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger);
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101CustomCodec.java
@@ -93,7 +93,7 @@ public abstract class Lucene101CustomCodec extends FilterCodec {
      *
      * @param mode The compression codec (ZSTD or ZSTDNODICT).
      * @param compressionLevel The compression level.
-     * @param defaultCodecSupplier Default codec supplier
+     * @param defaultCodecSupplier Default OpenSearch codec supplier
      */
     public Lucene101CustomCodec(Mode mode, int compressionLevel, Supplier<Codec> defaultCodecSupplier) {
         super(mode.getCodec(), defaultCodecSupplier.get());

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene101QatCodec.java
@@ -8,12 +8,10 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene101.Lucene101Codec;
-import org.opensearch.index.codec.PerFieldMappingPostingFormatCodec;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -105,12 +103,11 @@ public abstract class Lucene101QatCodec extends FilterCodec {
      * lucene_default, and best_compression.
      *
      * @param mode The compression codec (QAT_LZ4, QAT_DEFLATE, or QAT_ZSTD).
+     * @param defaultCodecSupplier default opensearch codec supplier
      * @param compressionLevel The compression level.
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      */
-    public Lucene101QatCodec(Mode mode, int compressionLevel, MapperService mapperService, Logger logger) {
-        super(mode.getCodec(), new PerFieldMappingPostingFormatCodec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger));
+    public Lucene101QatCodec(Mode mode, Supplier<Codec> defaultCodecSupplier, int compressionLevel) {
+        super(mode.getCodec(), defaultCodecSupplier.get());
         this.storedFieldsFormat = new Lucene101QatStoredFieldsFormat(mode, compressionLevel);
     }
 
@@ -121,18 +118,11 @@ public abstract class Lucene101QatCodec extends FilterCodec {
      *
      * @param mode The compression codec (QAT_LZ4, QAT_DEFLATE, or QAT_ZSTD).
      * @param compressionLevel The compression level.
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param supplier supplier for QAT mode.
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
-    public Lucene101QatCodec(
-        Mode mode,
-        int compressionLevel,
-        MapperService mapperService,
-        Logger logger,
-        Supplier<QatZipper.Mode> supplier
-    ) {
-        super(mode.getCodec(), new PerFieldMappingPostingFormatCodec(Lucene101Codec.Mode.BEST_SPEED, mapperService, logger));
+    public Lucene101QatCodec(Mode mode, int compressionLevel, Supplier<QatZipper.Mode> supplier, Supplier<Codec> defaultCodecSupplier) {
+        super(mode.getCodec(), defaultCodecSupplier.get());
         this.storedFieldsFormat = new Lucene101QatStoredFieldsFormat(mode, compressionLevel, supplier);
     }
 

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate101Codec.java
@@ -65,7 +65,8 @@ public class QatDeflate101Codec extends Lucene101QatCodec implements CodecSettin
      * Creates a new QatDeflate101Codec instance.
      *
      * @param compressionLevel The compression level.
-     * @param supplier supplier for QAT acceleration mode.
+     * @param supplier supplier for QAT acceleration mode
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
     public QatDeflate101Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier, Supplier<Codec> defaultCodecSupplier) {
         super(Mode.QAT_DEFLATE, compressionLevel, supplier, defaultCodecSupplier);

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate101Codec.java
@@ -8,12 +8,11 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.codec.CodecAliases;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -55,24 +54,21 @@ public class QatDeflate101Codec extends Lucene101QatCodec implements CodecSettin
     /**
      * Creates a new QatDeflate101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
+     * @param defaultCodecSupplier default opensearch codec supplier
      * @param compressionLevel The compression level.
      */
-    public QatDeflate101Codec(MapperService mapperService, Logger logger, int compressionLevel) {
-        super(Mode.QAT_DEFLATE, compressionLevel, mapperService, logger);
+    public QatDeflate101Codec(Supplier<Codec> defaultCodecSupplier, int compressionLevel) {
+        super(Mode.QAT_DEFLATE, defaultCodecSupplier, compressionLevel);
     }
 
     /**
      * Creates a new QatDeflate101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param compressionLevel The compression level.
      * @param supplier supplier for QAT acceleration mode.
      */
-    public QatDeflate101Codec(MapperService mapperService, Logger logger, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
-        super(Mode.QAT_DEFLATE, compressionLevel, mapperService, logger, supplier);
+    public QatDeflate101Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier, Supplier<Codec> defaultCodecSupplier) {
+        super(Mode.QAT_DEFLATE, compressionLevel, supplier, defaultCodecSupplier);
     }
 
     /** The name for this codec. */

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4101Codec.java
@@ -8,12 +8,11 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.codec.CodecAliases;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -55,24 +54,22 @@ public class QatLz4101Codec extends Lucene101QatCodec implements CodecSettings, 
     /**
      * Creates a new QatLz4101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
+     * @param defaultCodecSupplier default opensearch codec supplier
      * @param compressionLevel The compression level.
      */
-    public QatLz4101Codec(MapperService mapperService, Logger logger, int compressionLevel) {
-        super(Mode.QAT_LZ4, compressionLevel, mapperService, logger);
+    public QatLz4101Codec(Supplier<Codec> defaultCodecSupplier, int compressionLevel) {
+        super(Mode.QAT_LZ4, defaultCodecSupplier, compressionLevel);
     }
 
     /**
      * Creates a new QatLz4101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param compressionLevel The compression level.
      * @param supplier supplier for QAT acceleration mode.
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
-    public QatLz4101Codec(MapperService mapperService, Logger logger, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
-        super(Mode.QAT_LZ4, compressionLevel, mapperService, logger, supplier);
+    public QatLz4101Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier, Supplier<Codec> defaultCodecSupplier) {
+        super(Mode.QAT_LZ4, compressionLevel, supplier, defaultCodecSupplier);
     }
 
     /** The name for this codec. */

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZstd101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZstd101Codec.java
@@ -8,12 +8,11 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.codec.CodecAliases;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
 import java.util.function.Supplier;
@@ -55,24 +54,22 @@ public class QatZstd101Codec extends Lucene101QatCodec implements CodecSettings,
     /**
      * Creates a new QatZstd101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
+     * @param defaultCodecSupplier default opensearch codec supplier
      * @param compressionLevel The compression level.
      */
-    public QatZstd101Codec(MapperService mapperService, Logger logger, int compressionLevel) {
-        super(Mode.QAT_ZSTD, compressionLevel, mapperService, logger);
+    public QatZstd101Codec(Supplier<Codec> defaultCodecSupplier, int compressionLevel) {
+        super(Mode.QAT_ZSTD, defaultCodecSupplier, compressionLevel);
     }
 
     /**
      * Creates a new QatZstd101Codec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param compressionLevel The compression level.
      * @param supplier supplier for QAT acceleration mode.
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
-    public QatZstd101Codec(MapperService mapperService, Logger logger, int compressionLevel, Supplier<QatZipper.Mode> supplier) {
-        super(Mode.QAT_ZSTD, compressionLevel, mapperService, logger, supplier);
+    public QatZstd101Codec(int compressionLevel, Supplier<QatZipper.Mode> supplier, Supplier<Codec> defaultCodecSupplier) {
+        super(Mode.QAT_ZSTD, compressionLevel, supplier, defaultCodecSupplier);
     }
 
     /** The name for this codec. */

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Zstd101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Zstd101Codec.java
@@ -43,7 +43,7 @@ public class Zstd101Codec extends Lucene101CustomCodec implements CodecSettings,
      * Creates a new ZstdCodec instance.
      *
      * @param compressionLevel The compression level.
-     *
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
     public Zstd101Codec(int compressionLevel, Supplier<Codec> defaultCodecSupplier) {
         super(Mode.ZSTD, compressionLevel, defaultCodecSupplier);

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Zstd101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Zstd101Codec.java
@@ -8,14 +8,14 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.codec.CodecAliases;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.opensearch.index.codec.customcodecs.backward_codecs.lucene99.Lucene99CustomCodec.DEFAULT_COMPRESSION_LEVEL;
 
@@ -42,12 +42,11 @@ public class Zstd101Codec extends Lucene101CustomCodec implements CodecSettings,
     /**
      * Creates a new ZstdCodec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param compressionLevel The compression level.
+     *
      */
-    public Zstd101Codec(MapperService mapperService, Logger logger, int compressionLevel) {
-        super(Mode.ZSTD, compressionLevel, mapperService, logger);
+    public Zstd101Codec(int compressionLevel, Supplier<Codec> defaultCodecSupplier) {
+        super(Mode.ZSTD, compressionLevel, defaultCodecSupplier);
     }
 
     /** The name for this codec. */

--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDict101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDict101Codec.java
@@ -8,14 +8,14 @@
 
 package org.opensearch.index.codec.customcodecs;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.codec.CodecAliases;
 import org.opensearch.index.codec.CodecSettings;
 import org.opensearch.index.engine.EngineConfig;
-import org.opensearch.index.mapper.MapperService;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.opensearch.index.codec.customcodecs.backward_codecs.lucene99.Lucene99CustomCodec.DEFAULT_COMPRESSION_LEVEL;
 
@@ -39,12 +39,11 @@ public class ZstdNoDict101Codec extends Lucene101CustomCodec implements CodecSet
     /**
      * Creates a new ZstdNoDictCodec instance.
      *
-     * @param mapperService The mapper service.
-     * @param logger The logger.
      * @param compressionLevel The compression level.
+     * @param defaultCodecSupplier default opensearch codec supplier
      */
-    public ZstdNoDict101Codec(MapperService mapperService, Logger logger, int compressionLevel) {
-        super(Mode.ZSTD_NO_DICT, compressionLevel, mapperService, logger);
+    public ZstdNoDict101Codec(int compressionLevel, Supplier<Codec> defaultCodecSupplier) {
+        super(Mode.ZSTD_NO_DICT, compressionLevel, defaultCodecSupplier);
     }
 
     /** The name for this codec. */


### PR DESCRIPTION
### Description
This PR adds support for composite indices with custom codecs.
We delegate to the `CompositeCodec` instead of always delegating to PerFieldMappingPostingFormatCodec based on whether mapper has Composite fields.

### Related Issues
Resolves https://github.com/opensearch-project/custom-codecs/issues/209
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
