### PR TITLE
Fix typo: Recieved -> Received

### DIFF
--- a/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/helper/RestHelper.java
+++ b/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/helper/RestHelper.java
@@ -60,7 +60,7 @@ public class RestHelper {
         }
 
         Response response = client.performRequest(request);
-        log.info("Recieved response " + response.getStatusLine());
+        log.info("Received response " + response.getStatusLine());
         return response;
     }
 


### PR DESCRIPTION
Corrects "Recieved" -> "Received" in the bwc-test `RestHelper` response log.