### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
 
   repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://plugins.gradle.org/m2/" }
@@ -64,6 +65,7 @@ apply from: 'gradle/formatting.gradle'
 
 repositories {
   mavenLocal()
+  maven { url "https://ci.opensearch.org/maven2/" }
   mavenCentral()
   maven { url "https://plugins.gradle.org/m2/" }
   maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -51,6 +51,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -63,6 +64,7 @@ buildscript {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,13 @@
  * compatible open source license.
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "opensearch-custom-codecs"
 startParameter.excludedTaskNames=["publishPluginZipPublicationToStagingRepository"]


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid maven central throttling

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).