### PR TITLE
[Backport 2.19] Bump opensearch_version in bwc-test to 2.19.6-SNAPSHOT

### DIFF
--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,7 +44,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.5-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.6-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
     repositories {


### PR DESCRIPTION
### Description

Updates `opensearch_version` in `bwc-test/build.gradle` from 2.19.5-SNAPSHOT to 2.19.6-SNAPSHOT. This picks up log4j-core 2.25.4 from the updated build-tools, resolving CVE-2026-34480, CVE-2026-34478, and CVE-2026-34477.

### Issues Resolved

Resolves log4j-core CVEs with vulnerable range `>=2.0-alpha1 <2.25.4`.