### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,36 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".config",
+    ".png",
+    ".jar",
+    ".gz",
+    ".sha1",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".policy",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "src/main/resources/META-INF/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/ClusterType.java
+++ b/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/ClusterType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/CustomCodecsBwcCompatibilityIT.java
+++ b/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/CustomCodecsBwcCompatibilityIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/helper/RestHelper.java
+++ b/bwc-test/src/test/java/org/opensearch/customcodecs/bwc/helper/RestHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/integrationTest/java/org/opensearch/index/codec/rest/CreateIndexWithCodecIT.java
+++ b/src/integrationTest/java/org/opensearch/index/codec/rest/CreateIndexWithCodecIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/internalClusterTest/java/org/opensearch/index/codec/CodecCompressionLevelIT.java
+++ b/src/internalClusterTest/java/org/opensearch/index/codec/CodecCompressionLevelIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecMergeIT.java
+++ b/src/internalClusterTest/java/org/opensearch/index/codec/MultiCodecMergeIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomAdditionalCodecs.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomAdditionalCodecs.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/CustomCodecPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104QatCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104QatStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Lucene104QatStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatCompressionMode.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate104Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatDeflate104Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4104Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatLz4104Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZipperFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/QatZstd104Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/QatZstd104Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/Zstd104Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/Zstd104Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdCompressionMode.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDict104Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDict104Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Zstd95Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Zstd95Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Zstd95DeprecatedCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/Zstd95DeprecatedCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/ZstdNoDict95Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/ZstdNoDict95Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatDeflate101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatDeflate101Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatLz4101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatLz4101Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatZstd101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/QatZstd101Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Zstd101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Zstd101Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/ZstdNoDict101Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/ZstdNoDict101Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatDeflate103Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatDeflate103Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatLz4103Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatLz4103Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatZstd103Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/QatZstd103Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Zstd103Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Zstd103Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/ZstdNoDict103Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/ZstdNoDict103Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/QatDeflate912Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/QatDeflate912Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/QatLz4912Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/QatLz4912Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Zstd912Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Zstd912Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/ZstdNoDict912Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/ZstdNoDict912Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatCodec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatCodec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatStoredFieldsFormat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/QatDeflate99Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/QatDeflate99Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/QatLz499Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/QatLz499Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Zstd99Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Zstd99Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/ZstdNoDict99Codec.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/ZstdNoDict99Codec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/index/codec/customcodecs/package-info.java
+++ b/src/main/java/org/opensearch/index/codec/customcodecs/package-info.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/AbstractCompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/AbstractCompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/Lucene104CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/Lucene104CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/Lucene104QatStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/Lucene104QatStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/QatDeflateCompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/QatDeflateCompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/QatLz4CompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/QatLz4CompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/QatZstdCompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/QatZstdCompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/ZstdCompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/ZstdCompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressorTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/Lucene95CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene101/Lucene101QatStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene103/Lucene103QatStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene912/Lucene912QatStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99CustomStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/index/codec/customcodecs/backward_codecs/lucene99/Lucene99QatStoredFieldsFormatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/custom-codecs/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
