### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (custom-codecs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'com.diffplug.spotless' version '6.25.0'
+  id 'com.diffplug.spotless' version '8.10.1'
   id 'jacoco'
 }
 

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -9,6 +9,10 @@
  * GitHub history for details.
  */
 
+// Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+// Gradle invocations (test, assemble) don't provision the formatter at configuration time.
+def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
 spotless {
   java {
     target '**/*.java'
@@ -30,7 +34,13 @@ spotless {
         '\\#java|\\#org.opensearch|\\#org.hamcrest|\\#'
     )
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('gradle/formatterConfig.xml')
+    // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+    // formatter resolves from Maven Central through the mirror below instead of querying a
+    // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+    // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+    if (runningSpotlessTask) {
+      eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('gradle/formatterConfig.xml')
+    }
     trimTrailingWhitespace()
     endWithNewline()
 


### PR DESCRIPTION
### Description
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
